### PR TITLE
Specify psycopg2-binary.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq \
   && apt-get install -y python-pip python2.7-dev libldap2-dev libsasl2-dev libmysqlclient-dev \
   && pip install virtualenv
 RUN virtualenv /env
-RUN /env/bin/pip install pypicloud[ldap,dynamo]==$PYPICLOUD_VERSION requests uwsgi pastescript redis mysql-python psycopg2
+RUN /env/bin/pip install pypicloud[ldap,dynamo]==$PYPICLOUD_VERSION requests uwsgi pastescript redis mysql-python psycopg2-binary
 
 # Add the startup service
 RUN mkdir -p /etc/my_init.d


### PR DESCRIPTION
Build was failing with the following error:
```
[91m    ERROR: Command errored out with exit status 1:
     command: /env/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-17Fz94/psycopg2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-17Fz94/psycopg2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-17Fz94/psycopg2/pip-egg-info
         cwd: /tmp/pip-install-17Fz94/psycopg2/
    Complete output (23 lines):
    running egg_info
    creating /tmp/pip-install-17Fz94/psycopg2/pip-egg-info/psycopg2.egg-info
    writing /tmp/pip-install-17Fz94/psycopg2/pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to /tmp/pip-install-17Fz94/psycopg2/pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to /tmp/pip-install-17Fz94/psycopg2/pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file '/tmp/pip-install-17Fz94/psycopg2/pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    
    Error: pg_config executable not found.
    
    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:
    
        python setup.py build_ext --pg-config /path/to/pg_config build ...
    
    or with the pg_config option in 'setup.cfg'.
    
    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.
    
    For further information please check the 'doc/src/install.rst' file (also at
    <http://initd.org/psycopg/docs/install.html>).
    
    ----------------------------------------
```

Avoid the whole mess by using the psycopg2-binary package.